### PR TITLE
Fix and add hints to spark cluster setup

### DIFF
--- a/tutorial_06_spark_cluster_setup.md
+++ b/tutorial_06_spark_cluster_setup.md
@@ -16,7 +16,7 @@ sudo chown pi:hadoop -R /opt/spark
 mkdir /tmp/spark-events
 ```
 
-Add the following environment variables to `~/.environment_variables` and `source .` afterwards.
+Add the following environment variables to `~/.environment_variables` and `source ~/.environment_variables` afterwards.
 
 .environment_variables:
 
@@ -33,6 +33,18 @@ export LD_LIBRARY_PATH=$HADOOP_HOME/lib/native:$LD_LIBRARY_PATH
 
 ```bash
 source ~/.environment_variables
+```
+
+Then, you need to add an environment variable to Spark by typing
+
+```bash
+sudo vi /opt/spark/sbin/spark-config.sh
+```
+
+and adding
+
+```bash
+export JAVA_HOME=/opt/java/jdk1.8.0_371
 ```
 
 Verify the spark installation with `spark-shell --version`
@@ -65,6 +77,18 @@ spark.executor.cores 4
 spark.eventLog.enabled true
 spark.eventLog.dir file:///tmp/spark-events
 spark.history.fs.logDirectory file:///tmp/spark-events
+```
+
+On the Namenode (node01) only, create a `workers` file in the `/opt/spark/conf/` directory and add all nodes, one per line.
+
+workers:
+
+```
+node01
+node02
+node03
+node04
+node05
 ```
 
 Start the Spark cluster by executing the following commands only on the head node.

--- a/tutorial_06_spark_pyspark_setup.md
+++ b/tutorial_06_spark_pyspark_setup.md
@@ -6,16 +6,16 @@ You have already done the *Setup Hadoop* tutorial and have a cluster of five nod
 
 ### PySpark Installation
 
-First we add Spark to the Python path. Add the following line to the `.environment_variables` file and `source .` the changes.
+First we add Spark to the Python path. Add the following line to the `~/.environment_variables` file and `source ~/.environment_variables` the changes.
 
-.environment_variables:
+~/.environment_variables:
 
 ```bash
 export PYTHONPATH=$(ZIPS=("$SPARK_HOME"/python/lib/*.zip); IFS=:; echo "${ZIPS[*]}"):$PYTHONPATH
 ```
 
 ```bash
-source .
+source ~/.environment_variables
 ```
 
 Next we install Python, Pip and Venv with the following commands.

--- a/tutorial_06_spark_pyspark_word_count_example.md
+++ b/tutorial_06_spark_pyspark_word_count_example.md
@@ -10,7 +10,7 @@ After opening the Jupyter Ui create a new Notebook and add the following lines.
 
 ```bash
 # Import SparkSession
-from pyspark.sql import SparkSession, Row
+from pyspark.sql import SparkSession
 
 # Create SparkSession
 spark = SparkSession.builder \
@@ -18,7 +18,7 @@ spark = SparkSession.builder \
     .appName("WordCount") \
     .getOrCreate()
 
-sc = spark.SparkContext()
+sc = spark.sparkContext
 
 # Read the input file and Calculating words count
 text_file = sc.textFile("/WordCount/input/file01")


### PR DESCRIPTION
- Add `$JAVA_HOME` to `spark-config.sh`
- Add `workers` file to `/opt/spark/conf/`
- Fix bug in PySpark wordcount example
- Fix `source` commands