### PR TITLE
Enhanced Windows setup tutorial

### DIFF
--- a/tutorials/0_preperation/01_windows_connection_to_pi_cluster.md
+++ b/tutorials/0_preperation/01_windows_connection_to_pi_cluster.md
@@ -39,6 +39,7 @@ ifIndex InterfaceAlias               AddressFamily ConnectionState Forwarding
 ```
 
 Next we set the hostnames for our cluster nodes. Open an editor as an administrator and add at the bottom of file `C:\Windows\System32\drivers\etc\hosts` the following lines.
+Important: Only use spaces (no tabs etc.) as column delimiters!
 
 hosts:
 
@@ -46,10 +47,10 @@ hosts:
 [...]
 
 # Pi Cluster
-10.0.0.1	node01
-10.0.0.2	node02
-10.0.0.3	node03
-10.0.0.4	node04
+10.0.0.1    node01
+10.0.0.2    node02
+10.0.0.3    node03
+10.0.0.4    node04
 10.0.0.5	node05
 ```
 

--- a/tutorials/0_preperation/01_windows_connection_to_pi_cluster.md
+++ b/tutorials/0_preperation/01_windows_connection_to_pi_cluster.md
@@ -25,22 +25,10 @@ Next we enable IP forwarding. Open a Windows PowerShell as administrator and ena
 ```bash
 Set-NetIPInterface -Forwarding Enabled
 Get-NetIPInterface | select ifIndex,InterfaceAlias,AddressFamily,ConnectionState,Forwarding | Sort-Object -Property IfIndex | Format-Table
-
-ifIndex InterfaceAlias               AddressFamily ConnectionState Forwarding
-------- --------------               ------------- --------------- ----------
-      1 Loopback Pseudo-Interface 1           IPv6       Connected    Enabled
-      1 Loopback Pseudo-Interface 1           IPv4       Connected    Enabled
-      1 WLAN                                  IPv4       Connected    Enabled
-      3 Ethernet                              IPv6       Connected    Enabled
-      3 Ethernet                              IPv4       Connected    Enabled
 ```
 
-Next we enable IP forwarding. Open a Windows PowerShell as administrator and enable IP forwarding with `Set-NetIPInterface -Forwarding Enabled`. After that check if IP forwarding is activated with `Get-NetIPInterface | select ifIndex,InterfaceAlias,AddressFamily,ConnectionState,Forwarding | Sort-Object -Property IfIndex | Format-Table`.
-
-```bash
-Set-NetIPInterface -Forwarding Enabled
-Get-NetIPInterface | select ifIndex,InterfaceAlias,AddressFamily,ConnectionState,Forwarding | Sort-Object -Property IfIndex | Format-Table
-
+The output should look similar to this:
+```
 ifIndex InterfaceAlias               AddressFamily ConnectionState Forwarding
 ------- --------------               ------------- --------------- ----------
       1 Loopback Pseudo-Interface 1           IPv6       Connected    Enabled

--- a/tutorials/0_preperation/01_windows_internet_sharing.md
+++ b/tutorials/0_preperation/01_windows_internet_sharing.md
@@ -16,4 +16,6 @@ Under sharing check the checkbox and select the name of the network device conne
 
 ![networkSharing.png](../../pictures/networkSharing.png)
 
+Windows might have reset your network configuration of the Ethernet connection from last step after this, in which case you simply need to change it again.
+
 Done! Now your Pi cluster should have a working internet connection.


### PR DESCRIPTION
Did some small changes in the Windows tutorial part:
- removed duplicated paragraph and split command/output for easiert access
- replaced tabs by spaces in the hosts file example (since this seemed to be important in my case and is at least the recommended style)
- added a note regarding Windows being Windows and breaking stuff